### PR TITLE
Fix wizard onchange and deletion controls

### DIFF
--- a/ld_batch_payment_allocation/views/batch_payment_wizard_views.xml
+++ b/ld_batch_payment_allocation/views/batch_payment_wizard_views.xml
@@ -35,10 +35,12 @@
                             <field name="residual_in_company_currency" widget="monetary" readonly="1"/>
                             <field name="amount_to_pay"/>
                             <field name="currency_id" readonly="1"/>
+                            <field name="to_delete" widget="boolean_toggle"/>
                         </list>
                     </field>
                 </group>
                 <footer>
+                    <button name="action_remove_selected_lines" string="Remove Selected Lines" type="object" class="btn-secondary"/>
                     <button string="Cancel" class="btn-secondary" special="cancel"/>
                     <button name="action_allocate" string="Generate Payment" type="object" class="btn-primary"/>
                 </footer>

--- a/ld_batch_payment_allocation/wizards/batch_payment_wizard.py
+++ b/ld_batch_payment_allocation/wizards/batch_payment_wizard.py
@@ -259,6 +259,7 @@ class BatchPaymentAllocationWizardLine(models.TransientModel):
                 rec.amount_to_pay = 0.0
 
 
+    @api.onchange("move_id")
     def _onchange_move(self):
         for rec in self:
             rec.name = rec.move_id.name or ""
@@ -271,6 +272,7 @@ class BatchPaymentAllocationWizardLine(models.TransientModel):
                 rec.residual_in_invoice_currency = residual_invoice
                 # refresh payment-currency residual via wizard conversion
                 rec.residual_in_payment_currency = rec.wizard_id._convert_amount(residual_company, rec.wizard_id.payment_date)
+                rec.amount_to_pay = rec.residual_in_payment_currency
 
     def action_delete_line(self):
         self.unlink()


### PR DESCRIPTION
## Summary
- trigger the invoice line onchange when selecting a move and prefill residual amounts
- expose the delete flag on invoice lines and add an action to drop the selected lines from the wizard

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5dd2d0f10832695bf0fde1ab6ca35